### PR TITLE
Added in the "break_word" parameter

### DIFF
--- a/README
+++ b/README
@@ -12,11 +12,12 @@ with the exp:eehive_hacksaw tag, like this:
 There are several parameters you can use to control how
 the content is truncated. These options are:
 
-chars   = ""     // Limit by number of characters
-words   = ""     // Limit by number of words
-cutoff  = ""     // Limit by a specific cutoff string
-append  = ""     // String to append to the end of the excerpt
-allow   = ""     // HTML tags you want to allow. Ex allow="<b><a>"
+chars      = ""     // Limit by number of characters
+break_word = ""     // Break the string in the middle of a word? (Only used when limiting chars. Defaults to Yes) 
+words      = ""     // Limit by number of words
+cutoff     = ""     // Limit by a specific cutoff string
+append     = ""     // String to append to the end of the excerpt
+allow      = ""     // HTML tags you want to allow. Ex allow="<b><a>"
 
 For example, if you want to limit your excerpt to 100
 words you would do this:
@@ -61,5 +62,30 @@ You can add any string at the end of the excerpt using the
 {/exp:eehive_hacksaw}
 
 This would append "..." to the end of the excerpt.
+
+The 'break_word' parameter allows you to decide how you want the char limit
+to behave if it ends in the middle of a word. It will default to slicing the 
+string wherever the char limit falls. If you add 'break_word="no"' it will
+fall back to the closest space and cut the string there. 
+
+Example:
+
+{exp:eehive_hacksaw chars="13" append="..."}
+String of content
+{/exp:eehive_hacksaw}
+
+would be: 
+
+'String of cont...'
+
+By adding the break_word="no" the result of this: 
+
+{exp:eehive_hacksaw chars="13" append="..." break_word="no"}
+String of content
+{/exp:eehive_hacksaw}
+
+would be: 
+
+'String of...'
 
 For complete documentation go to http://www.ee-hive.com/hacksaw

--- a/system/third_party/eehive_hacksaw/pi.eehive_hacksaw.php
+++ b/system/third_party/eehive_hacksaw/pi.eehive_hacksaw.php
@@ -4,7 +4,7 @@ if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
 $plugin_info = array(
   'pi_name' => 'EE Hive Hacksaw',
-  'pi_version' => '1.07',
+  'pi_version' => '1.0.8',
   'pi_author' => 'EE Hive - Brett DeWoody',
   'pi_author_url' => 'http://www.ee-hive.com/add-ons/hacksaw',
   'pi_description' => 'Allows you to create excerpts of your entries by removing HTML tags and limited the excerpt by character count, word count or a specific marker you insert into your content.',
@@ -45,6 +45,7 @@ var $return_data = "";
 	$chars = $this->EE->TMPL->fetch_param('chars');
 	$chars_start = ($this->EE->TMPL->fetch_param('chars_start') ? $this->EE->TMPL->fetch_param('chars_start') : 0);
 	$words = $this->EE->TMPL->fetch_param('words');
+	$break_word = $this->EE->TMPL->fetch_param('break_word', 'yes');
 	$cutoff = $this->EE->TMPL->fetch_param('cutoff');
 	$append = $this->EE->TMPL->fetch_param('append', '');
 	$allow = $this->EE->TMPL->fetch_param('allow');
@@ -56,7 +57,7 @@ var $return_data = "";
 	} elseif (isset($chars) && $chars != "") {
 		// Strip the HTML
 		$stripped_content = strip_tags($tag_content, $allow);
-		$new_content = (strlen($stripped_content) <= $chars ? $stripped_content : $this->_truncate_chars($stripped_content, $chars_start, $chars, $append));
+		$new_content = (strlen($stripped_content) <= $chars ? $stripped_content : $this->_truncate_chars($stripped_content, $chars_start, $chars, $append, $break_word));
 	} elseif (isset($words) && $words != "") {
 		// Strip the HTML
 		$stripped_content = strip_tags($tag_content, $allow);
@@ -84,9 +85,16 @@ var $return_data = "";
     }
 	
   // Helper Function - Truncate by Character Limit
-  function _truncate_chars($content, $chars_start, $limit, $append) {
+  function _truncate_chars($content, $chars_start, $limit, $append, $break_word) {
     // Removing the below to see how it effect UTF-8. 
-    $content = preg_replace('/\s+?(\S+)?$/', '', substr($content, $chars_start, ($limit+1))) . $append;
+		if(strtolower($break_word) == 'yes')
+		{
+			$content = substr($content, $chars_start, ($limit+1)) . $append;
+		}
+		else
+		{
+			$content = preg_replace('/\s+?(\S+)?$/', '', substr($content, $chars_start, ($limit+1))) . $append;	
+		}
     return $content;
   }
   
@@ -127,6 +135,7 @@ cutoff marker.
 {exp:eehive_hacksaw
 	chars = "" // Limit by number of characters
 	chars_start = "" // Used with the 'chars' parameter, this starts the excerpt at X characters from the beginning of the content
+	break_word = "" // Used with 'chars' parameter to determine whether to break the string in the middle of a word. Defaults to "yes"
     words = "" // Limit by number of words
     cutoff = "" // Limit by a specific cutoff string
     append = "" // String to append to the end of the excerpt


### PR DESCRIPTION
This adds the functionality to break a string in the middle of a word if the chars line up in the middle of a word instead of rolling back to the closest space.
