### PR TITLE
Fix method to add PHP 5.6 support

### DIFF
--- a/system/third_party/eehive_hacksaw/pi.eehive_hacksaw.php
+++ b/system/third_party/eehive_hacksaw/pi.eehive_hacksaw.php
@@ -115,7 +115,7 @@ var $return_data = "";
 	
   //  Make sure and use output buffering
 
-  function usage()
+  function static function usage()
   {
   ob_start(); 
   ?>

--- a/system/third_party/eehive_hacksaw/pi.eehive_hacksaw.php
+++ b/system/third_party/eehive_hacksaw/pi.eehive_hacksaw.php
@@ -115,7 +115,7 @@ var $return_data = "";
 	
   //  Make sure and use output buffering
 
-  function static function usage()
+  public static function usage()
   {
   ob_start(); 
   ?>


### PR DESCRIPTION
Changed usage function to a public static function for PHP 5.6 compatibility.

Methods called from an incompatible context are now deprecated, and will generate E_DEPRECATED errors when invoked instead of E_STRICT. Support for these calls will be removed in a future version of PHP. 

http://php.net/manual/en/migration56.deprecated.php
